### PR TITLE
Added and broke device tests.  Broke technician test.  Generic methods to be added to BaseModel class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1 - 2023-12-31]
+
+### Added
+- DB test fixture for testing `Device` repository methods.
+- Added functionality for `Device` to be updated in the database.
+- Added test cases for updating `Device` in the database.
+
+### Changed
+
+- get_by_id repository methods return all rows with the given id.
+
+### TODO
+
+- Add generic get_all method to base model class.
+- Add generic get_by_id method to base model class.
+- Add generic update method to base model class.
+- Add generic delete method to base model class.
+
+
 ## [0.2 - 2023-12-31]
 
 ### Added

--- a/scheduler/models/device_model.py
+++ b/scheduler/models/device_model.py
@@ -2,11 +2,10 @@
 
 from .base_model import BaseModel
 
-# Device class for handling device data and operations
+# Device class for handling device data
 class Device(BaseModel):
     def __init__(self, id, name, make, model, description, db):
         super().__init__(db)
-        self.db = db
         self.id = id
         self.name = name
         self.make = make

--- a/scheduler/models/technician_model.py
+++ b/scheduler/models/technician_model.py
@@ -6,8 +6,6 @@ from .base_model import BaseModel
 class Technician(BaseModel):
     def __init__(self, id, name, availability, tasks, db):
         super().__init__(db)
-
-        self.db = db
         self.id = id
         self.name = name
         self.availability = availability

--- a/scheduler/repositories/device_repository.py
+++ b/scheduler/repositories/device_repository.py
@@ -2,22 +2,22 @@
 
 from ..models.device_model import Device
 
-# Device class for handling device data and operations
+# DeviceRepository class for handling device database operations
 class DeviceRepository:
     def __init__(self, database):
         self.database = database
 
-    def insert(self, name, availability):
-        self.database.insert_technician(name, availability)
+    def insert(self, **kwargs):
+        self.database.insert_technician(**kwargs)
 
     def get_by_id(self, id):
         row = self.database.fetch_by_id('Devices', id)
         if row is None:
             return None
-        return Device(row[0], row[1], row[2], [], self.database)
+        return Device(*row, self.database)
 
-    def update(self, id, name, availability):
-        self.database.update_technician(id, name, availability)
+    def update(self, id, **kwargs):
+        self.database.update_technician(id, **kwargs)
 
     def delete(self, id):
         self.database.delete_technician(id)

--- a/scheduler/repositories/technician_repository.py
+++ b/scheduler/repositories/technician_repository.py
@@ -7,17 +7,17 @@ class TechnicianRepository:
     def __init__(self, database):
         self.database = database
 
-    def insert(self, name, availability):
-        self.database.insert_technician(name, availability)
+    def insert(self, **kwargs):
+        self.database.insert_technician(**kwargs)
 
     def get_by_id(self, id):
         row = self.database.fetch_by_id('Technicians', id)
         if row is None:
             return None
-        return Technician(row[0], row[1], row[2], [], self.database)
+        return Technician(*row, self.database)
 
-    def update(self, id, name, availability):
-        self.database.update_technician(id, name, availability)
+    def update(self, id, **kwargs):
+        self.database.update_technician(id, **kwargs)
 
     def delete(self, id):
         self.database.delete_technician(id)

--- a/tests/test_device_model.py
+++ b/tests/test_device_model.py
@@ -1,0 +1,26 @@
+# Path: tests/test_device_model.py
+
+import pytest
+from ..scheduler.models.device_model import Device
+
+class TestDevice:
+    @pytest.fixture
+    def device(self, mocker):
+        db = mocker.Mock()
+        return Device(1, 'Device 1', 'Make 1', 'Model 1', 'Description 1', db)
+
+    def test_init(self, device, mocker):
+        assert device.id == 1
+        assert device.name == 'Device 1'
+        assert device.make == 'Make 1'
+        assert device.model == 'Model 1'
+        assert device.description == 'Description 1'
+        assert isinstance(device.db, mocker.Mock)
+
+    def test_update(self, device, mocker):
+        device.update('Device 2', 'Make 2', 'Model 2', 'Description 2')
+        assert device.name == 'Device 2'
+        assert device.make == 'Make 2'
+        assert device.model == 'Model 2'
+        assert device.description == 'Description 2'
+        device.db.update_device.assert_called_once_with(device)

--- a/tests/test_device_repository.py
+++ b/tests/test_device_repository.py
@@ -1,0 +1,40 @@
+# Path: tests/test_device_repository.py
+
+import pytest
+from ..scheduler.repositories.device_repository import DeviceRepository
+from ..scheduler.models.device_model import Device
+
+class TestDeviceRepository:
+    @pytest.fixture
+    def db(self, mocker):
+        return mocker.Mock()
+
+    @pytest.fixture
+    def device_repository(self, mocker):
+        db = mocker.Mock()
+        return DeviceRepository(db)
+
+    def test_insert(self, device_repository, mocker):
+        device_repository.insert('Device 1', 'Make 1', 'Model 1', 'Description 1', True)
+        device_repository.database.insert_device.assert_called_once_with('Device 1', 'Make 1', 'Model 1', 'Description 1', True)
+
+    def test_get_by_id(self, device_repository, mocker):
+        mock_data = [1, 'Device 1', 'Make 1', 'Model 1', 'Description 1', True]
+        device_repository.database.fetch_by_id.return_value = mock_data
+        device = device_repository.get_by_id(1)
+        device_repository.database.fetch_by_id.assert_called_once_with('Devices', 1)
+        assert isinstance(device, Device)
+        assert list(device.__dict__.values()) == mock_data
+
+    def test_update(self, device_repository, mocker):
+        device_repository.update(1, 'Device 2', False)
+        device_repository.database.update_technician.assert_called_once_with(1, 'Device 2', False)
+
+    def test_delete(self, device_repository, mocker):
+        device_repository.delete(1)
+        device_repository.database.delete_technician.assert_called_once_with(1)
+
+    def test_get_by_id_none(self, device_repository, mocker):
+        device_repository.database.fetch_by_id.return_value = None
+        device = device_repository.get_by_id(1)
+        assert device is None


### PR DESCRIPTION
The intention is to move all generic CRUD methods to the BaseModel class where applicable.  Models should accept all keyword arguments and ideally only be defined explicitly in one place.